### PR TITLE
fix: remove invalid address from sextortion_talos tagpack

### DIFF
--- a/packs/sextortion_talos.yaml
+++ b/packs/sextortion_talos.yaml
@@ -17825,7 +17825,6 @@ tags:
 - address: 18zr3brzdbfeT8Ds16T5wx7xpS9m13NZS6
 - address: 18zuKVA2eTwmu3bozFe6D7jbkGsHmdcnFD
 - address: 18zzPvBhmScwEBK1fbsZgtz9FLxq7bm8Jb
-- address: '19'
 - address: 1911AdrKrypAsfGXsB9hFsVcZBXoixtsMK
 - address: 1913Ghh9X8pmSPAde1ezz5xJa9Y3fTctEV
 - address: 1918AcyPEFuo8ebDdujBScQGC8wrNNxvRG


### PR DESCRIPTION
The file sextortion_talos.yaml contains an invalid address ("19") that I have removed.